### PR TITLE
fix code

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -79,7 +79,7 @@ int main()
      msg.len =8;
     MX_UART4_DMA_Init();
     MX_UART4_Init();
-    //printf("HAL_UART_Receive_DMA() return %d\r\n",HAL_UART_Receive_DMA(&huart4, propoMainBuf,PROPO_MAINBUF_SIZE)); // プロポと通信開始(SerialDMA)
+    printf("HAL_UART_Receive_DMA() return %d\r\n",HAL_UART_Receive_DMA(&huart4, propoMainBuf,PROPO_MAINBUF_SIZE)); // プロポと通信開始(SerialDMA)
   
     while (1) {
     
@@ -131,12 +131,12 @@ int main()
 
     //printf("%d %d %d %d %d\n", msg.data[2]<<8,msg.data[2],msg.data[3],(msg.data[2]<<8)+msg.data[3],shift_data_msg);
 
-    printf("rpm:%d stickData[2]:%f  \n",shift_data_msg,stickData[2]);
-     
-    }
-     while(t.read_us() <= 1000){};
+    //printf("rpm:%d stickData[2]:%f  \n",shift_data_msg,stickData[2]);
+        while(t.read_us() <= 1000){};
         t.stop();
         t.reset();
+    }
+
      
 }
 


### PR DESCRIPTION
推測ではありますが
俗に言うwhileタイマーが

https://github.com/keiji1112/GM6020-/blob/9e4d737060edca881684732b796e4e33649d058e/main.cpp#L137-L139

この86行目から始まるwhile文の外にあり
https://github.com/keiji1112/GM6020-/blob/9e4d737060edca881684732b796e4e33649d058e/main.cpp#L84

134行目のprintfをコメントアウトすると
https://github.com/keiji1112/GM6020-/blob/9e4d737060edca881684732b796e4e33649d058e/main.cpp#L134

105のDMAを開始してから
https://github.com/keiji1112/GM6020-/blob/9e4d737060edca881684732b796e4e33649d058e/main.cpp#L105

87行目のpropoMainBuf[0]を参照するまでの時間がとても短くなります． 
そのため1Byteを受信する前に参照されて条件文がtrueにならない可能性があります．
https://github.com/keiji1112/GM6020-/blob/9e4d737060edca881684732b796e4e33649d058e/main.cpp#L87

これで治らなければ
HAL関数の使用方法に問題があるかもしれません．
